### PR TITLE
Add AttributeError to ElementsCallbackData.__getattr__

### DIFF
--- a/streamlit_elements/core/callback.py
+++ b/streamlit_elements/core/callback.py
@@ -138,7 +138,7 @@ class ElementsCallbackData(dict):
         try: 
             return self.__getitem__(value)
         except:
-            raise AttributeError('{value} is not a valid attribute')
+            raise AttributeError(f'{value} is not a valid attribute')
 
 def _get_parameters(function):
     return (

--- a/streamlit_elements/core/callback.py
+++ b/streamlit_elements/core/callback.py
@@ -135,8 +135,10 @@ class ElementsCallbackData(dict):
     __slots__ = ()
 
     def __getattr__(self, value):
-        return self.__getitem__(value)
-
+        try: 
+            return self.__getitem__(value)
+        except:
+            raise AttributeError('{value} is not a valid attribute')
 
 def _get_parameters(function):
     return (


### PR DESCRIPTION
From here:
https://docs.python.org/3/reference/datamodel.html?highlight=__getattr__#object.__getattr

object.__getattr__(self, name)
This method should either return the (computed) attribute value or raise an AttributeError

Right now the function throws a KeyError when it gets a wrong argument, which makes the streamit_elements components unusable with pickle, deepcopy and other standard python libraries because they expect ArgumentError
